### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -178,7 +178,7 @@ Binaries for Varnish 6.0 LTS (CentOS / RedHat 7)
 
 ::
 
-    yum -y install https://extras.getpagespeed.com/release-el7-latest.rpm
+    yum -y install https://extras.getpagespeed.com/release-el7-latest.rpm yum-utils
     yum-config-manager --enable getpagespeed-extras-varnish60
     yum install vmod-xcounter
 

--- a/README.rst
+++ b/README.rst
@@ -173,6 +173,22 @@ Example
 INSTALLATION
 ============
 
+Binaries for Varnish 6.0 LTS (CentOS / RedHat 7)
+-------------------------------------------------
+
+::
+
+    yum -y install https://extras.getpagespeed.com/release-el7-latest.rpm
+    yum-config-manager --enable getpagespeed-extras-varnish60
+    yum install vmod-xcounter
+
+More on the VMODs repository `here <https://www.getpagespeed.com/redhat>`_.
+
+Compilation
+---------------------
+
+For other platforms you would use compilation.
+
 The source tree is based on autotools to configure the building, and
 does also have the necessary bits in place to do functional unit tests
 using the ``varnishtest`` tool.


### PR DESCRIPTION
The module was packaged and made available for CentOS / RedHat 7 and Varnish 6.0 LTS. The Readme update is for binary installation of the VMOD via yum repository (more details here https://www.getpagespeed.com/server-setup/how-to-install-vmod-xcounter-for-varnish-6-0-lts )